### PR TITLE
[JENKINS-59508] Sidebar links show full label on hover

### DIFF
--- a/core/src/main/resources/lib/layout/task.jelly
+++ b/core/src/main/resources/lib/layout/task.jelly
@@ -207,7 +207,7 @@ THE SOFTWARE.
               </l:confirmationLink>
             </j:when>
             <j:otherwise>
-              <a href="${href}" class="task-link" onclick="${attrs.onclick ?: (post ? 'return postRequest_' + id + '(this)' : null)}">
+              <a href="${href}" class="task-link" onclick="${attrs.onclick ?: (post ? 'return postRequest_' + id + '(this)' : null)}" title="${title}">
                 <j:choose>
                   <j:when test="${match}">
                     <b>${title}</b>


### PR DESCRIPTION
See [JENKINS-59508](https://issues.jenkins-ci.org/browse/JENKINS-59508).

The text overflow was solved by the PR [#4121]( https://github.com/jenkinsci/jenkins/pull/4121).
As per the conversation on the ticket comments, I'm adding an option to show the full sidebar link name on hover using the HTML `title` attribute.

This change is applied to all sidebar links, not just the ones cropped. If we want to only show it for cropped links we would need to introduce some JS code

There's a video uploaded to the ticket that shows the solution's behaviour.

#### Tests

I did not add any automated test because it's just an attribute addition. I surely add one if needed.



### Proposed changelog entries

* Entry 1: Minor UI changes.
   Shows a tooltip with the full link name when hovering over sidebar links

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs


### Desired reviewers

