### PR TITLE
[JENKINS 60921] Revisit base typography

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/_table.css
+++ b/core/src/main/resources/hudson/PluginManager/_table.css
@@ -13,7 +13,7 @@ time {
     text-align: right;
 }
 .plugin-manager__categories {
-    margin-top: 0.5em;
+    margin-top: 0.25em;
 }
 
 .plugin-manager__category-label {
@@ -21,6 +21,7 @@ time {
     border: 1px solid #ccc;
     background-color: #eee;
     border-radius: 4px;
-    padding: 0.25rem;
+    font-size: 0.75rem;
+    padding: 0 0.5rem;
     margin: 0 0.25rem 0.25rem 0;
 }

--- a/core/src/main/resources/hudson/PluginManager/advanced.jelly
+++ b/core/src/main/resources/hudson/PluginManager/advanced.jelly
@@ -35,7 +35,7 @@ THE SOFTWARE.
       <table id="pluginsAdv" class="pane" style="margin-top:0; border-top:none">
         <tr style="border-top:none; white-space: normal">
           <td>
-              <h1>${%HTTP Proxy Configuration}</h1>
+              <h2>${%HTTP Proxy Configuration}</h2>
               <f:form method="post" action="proxyConfigure" name="proxyConfigure">
                 <j:scope>
                   <j:set var="instance" value="${app.proxy}"/>
@@ -47,7 +47,7 @@ THE SOFTWARE.
                 </f:block>
               </f:form>
 
-              <h1>${%Upload Plugin}</h1>
+              <h2>${%Upload Plugin}</h2>
               <f:form method="post" action="uploadPlugin" name="uploadPlugin" enctype="multipart/form-data">
                 <f:block>
                   <div style="margin-bottom: 1em;">
@@ -63,7 +63,7 @@ THE SOFTWARE.
                 </f:block>
               </f:form>
 
-              <h1>${%Update Site}</h1>
+              <h2>${%Update Site}</h2>
               <f:form method="post" action="siteConfigure" name="siteConfigure">
                 <f:entry title="${%URL}" >
                   <f:textbox name="site" value="${app.updateCenter.getSite(app.updateCenter.ID_DEFAULT).url}" />
@@ -79,7 +79,7 @@ THE SOFTWARE.
                 </j:if>
               </j:forEach>
               <j:if test="${hasNonDefault}">
-                <h2>${%Other Sites}</h2>
+                <h2 class="h4">${%Other Sites}</h2>
                 <ul>
                   <j:forEach var="site" items="${app.updateCenter.sites}">
                     <j:if test="${site.id != app.updateCenter.ID_DEFAULT}">

--- a/core/src/main/resources/hudson/model/View/newJob.jelly
+++ b/core/src/main/resources/hudson/model/View/newJob.jelly
@@ -38,7 +38,7 @@ THE SOFTWARE.
           <form method="post" action="createItem" name="createItem" id="createItem">
             <div class="header">
               <div class="add-item-name">
-                <label for="name">${%ItemName.label}</label>
+                <label for="name" class="h3">${%ItemName.label}</label>
                 <input name="name" id="name" data-valid="false" type="text" tabindex="0" />
                 <div class="input-help">&#187; ${%ItemName.help}</div>
                 <div id="itemname-required" class="input-validation-message input-message-disabled">&#187; ${%ItemName.validation.required}</div>

--- a/core/src/main/resources/jenkins/install/SetupWizard/setupWizardConfigureInstance.jelly
+++ b/core/src/main/resources/jenkins/install/SetupWizard/setupWizardConfigureInstance.jelly
@@ -26,7 +26,6 @@ THE SOFTWARE.
 
   <l:layout norefresh="true" type="full-screen" title="${it.displayName}">
     <l:main-panel>
-      <link rel="stylesheet" href="${resURL}/css/google-fonts/roboto/css/roboto.css" type="text/css" />
       <style type="text/css">
         #configure-instance {
           padding: 20px 100px 20px 100px;
@@ -38,7 +37,6 @@ THE SOFTWARE.
         }
 
         #configure-instance h1 {
-          font-family: 'roboto', sans-serif;
           font-size: 48px;
           margin-top: 30px;
           font-weight: 500;

--- a/core/src/main/resources/jenkins/install/SetupWizard/setupWizardFirstUser.jelly
+++ b/core/src/main/resources/jenkins/install/SetupWizard/setupWizardFirstUser.jelly
@@ -3,9 +3,7 @@
 
   <l:layout type="full-screen" title="${it.displayName}">
     <l:main-panel>
-      <link rel="stylesheet" href="${resURL}/css/google-fonts/roboto/css/roboto.css" type="text/css" />
       <style type="text/css">
-
         #create-admin-user {
           padding: 20px 100px 20px 100px;
           margin: 8px;
@@ -16,7 +14,6 @@
         }
 
         #create-admin-user h1 {
-          font-family: 'roboto', sans-serif;
           font-size: 48px;
           line-height: 48px;
           margin-top: 30px;

--- a/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
@@ -29,7 +29,6 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 <l:layout title="${%Manage Jenkins}" permissions="${app.MANAGE_AND_SYSTEM_READ}">
   <l:header>
-     <link rel="stylesheet" href="${resURL}/bootstrap/css/bootstrap.min.css" type="text/css" />
      <link rel="stylesheet" href="${resURL}/css/font-awesome/css/font-awesome.min.css" />
   </l:header>
 

--- a/core/src/main/resources/jenkins/security/ApiTokenProperty/resources.css
+++ b/core/src/main/resources/jenkins/security/ApiTokenProperty/resources.css
@@ -34,7 +34,7 @@
 .token-list .token-list-item {
     min-height: inherit;
     padding: 8px 10px;
-    font-size: 13px;
+    font-size: 0.875rem;
     line-height: 26px;
 }
 .token-list .token-list-item.legacy-token {
@@ -56,7 +56,7 @@
 }
 .token-list .token-list-item .token-creation{
     margin-left: 5px;
-    font-size: 90%;
+    font-size: 0.75rem;
 }
 .token-list .token-list-item .token-creation.age-ok{
     color: #6d7680;
@@ -74,11 +74,11 @@
     float: right;
 }
 .token-list .token-list-item .token-use-counter{
-    font-size: 90%;
+    font-size: 0.75rem;
     color: #6d7680;
 }
 .token-list .token-list-item .no-statistics{
-    font-size: 90%;
+    font-size: 0.75rem;
     color: #6d7680;
 }
 .token-list .token-list-item .token-revoke{
@@ -105,8 +105,8 @@
     width: 40%; 
     display: none;
     font-family: monospace;
-    font-size: 14px;
     margin-right: 2px; 
+    font-size: 1em;
 }
 .token-list .token-list-new-item .new-token-value.visible{
     display: inline-block;

--- a/core/src/main/resources/lib/layout/breadcrumbs.css
+++ b/core/src/main/resources/lib/layout/breadcrumbs.css
@@ -18,17 +18,8 @@
     min-height: 2.5rem;
     font-size: 1rem;
     line-height: 1.5;
-    font-family: Roboto, Helvetica, Arial, sans-serif;
     padding: 0 1.25rem;
     background-color: #F8F8F8;
-}
-
-/*
-  Revert the font change to the options menu.
-  It's used all over the application and having Roboto may make it clash with other UI elements
-*/
-#breadcrumb-menu {
-    font-family: Helvetica, Arial, sans-serif;
 }
 
 #breadcrumbs {

--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -159,7 +159,6 @@ THE SOFTWARE.
     <link rel="stylesheet" href="${resURL}/scripts/yui/menu/assets/skins/sam/menu.css" type="text/css" />
     <!--link rel="stylesheet" href="${resURL}/scripts/yui/editor/assets/skins/sam/editor.css" type="text/css" /-->
 
-    <link rel="stylesheet" href="${resURL}/css/google-fonts/roboto/css/roboto.css" type="text/css" />
     <link rel="stylesheet" href="${resURL}/jsbundles/ui-refresh-overrides.css" type="text/css" />
 
     <l:hasPermission permission="${app.READ}">

--- a/war/src/main/js/widgets/add/addform.less
+++ b/war/src/main/js/widgets/add/addform.less
@@ -1,3 +1,5 @@
+@import '../../../less/abstracts/font.less';
+
 #add-item-panel {
 
   form > .header {
@@ -47,7 +49,7 @@
         border-style: solid;
         color: rgb(80, 80, 80);
         font-weight: bold;
-        font-size: 12px;
+        font-size: @font-size-sm;
         line-height: 27px;
       }
 
@@ -58,7 +60,7 @@
         cursor: pointer;
       }
 
-      button[type=submit]:active:not(.disabled){        
+      button[type=submit]:active:not(.disabled){
         box-shadow: inset 0px 1px 6px 2px #1b2b33;
       }
 
@@ -77,9 +79,7 @@
 
     label {
       position: relative;
-      display: block;
-      font-size: 22px;
-      font-weight: bold;
+      // TODO: use default margin
       padding-bottom: 10px;
     }
   }
@@ -92,7 +92,7 @@
     background-color: #f9f9f9;
 
     p.description {
-      font-size: 16px;
+      font-size: @font-size-base;
       margin-top: 0;
     }
 
@@ -101,7 +101,7 @@
       padding-left: 58px;
 
       /* This is needed because <s:textbox /> included YUI styles and we need to override this one */
-      font-family: Helvetica, Arial, sans-serif !important;
+      font-family: @font-family-sans !important;
 
       input[type=radio] {
         display: none;
@@ -127,7 +127,7 @@
     .input-help {
       color: #666;
       font-style: italic;
-      font-size: 13px;
+      font-size: @font-size-sm;
       padding-top: 2px;
     }
 
@@ -243,7 +243,6 @@
   }
 
   input {
-    font-size: 1.5em;
     background-color: #fff;
     padding: 5px 10px;
     border: 1px solid #999;
@@ -352,7 +351,7 @@
 
     label {
       display: block;
-      font-size: 1.1em;
+      font-size: @font-size-base;
       font-weight: bold;
       color: #000;
       padding-bottom: 5px;

--- a/war/src/main/js/widgets/config/tabbar.less
+++ b/war/src/main/js/widgets/config/tabbar.less
@@ -2,6 +2,8 @@
  * Tab bar specific rules.
  */
 
+@import '../../../less/abstracts/font.less';
+
 .jenkins-config-widgets {
   position: relative;
   border:1px solid @solid-border;
@@ -41,7 +43,7 @@
     cursor: pointer;
     color: @solid-border;
     text-shadow: @brightest 0 1px 2px;
-    font-size: 0.85em;
+    font-size: @font-size-sm;
     padding: 3px 7px;
     display:none;
   }
@@ -173,7 +175,7 @@
 
       .section-header{
         margin: 30px 0px 5px -10px;
-        font-size: 1.5em;
+        font-size: 1.25rem;
         padding: 10px 15px;
         border: none;
         border-top: 1px solid #ddd;
@@ -238,9 +240,8 @@
         p,
         .help,
         .setting-description {
-          font-size:1em;
-          line-height:1.4;
-        } 
+          font-size: @font-size-base;
+        }
       }
       td[colspan="4"]:empty{
         display:none

--- a/war/src/main/less/abstracts/colors.less
+++ b/war/src/main/less/abstracts/colors.less
@@ -27,3 +27,6 @@
 // Breadcrumbs and footer
 @breadcrumbs-bg: #f8f8f8;
 @breadcrumbs-border: #EAEFF2;
+
+// Typography
+@text-color: #333;

--- a/war/src/main/less/abstracts/font.less
+++ b/war/src/main/less/abstracts/font.less
@@ -1,0 +1,9 @@
+@font-family-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Noto Sans", Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+
+@font-size-base: 1rem; // 16px
+@font-size-sm: 0.875rem; // 14px
+@font-size-xs: 0.75rem; // 12px
+@font-size-monospace: 0.95em;
+
+@line-height-base: 1.5;
+@line-height-heading: 1.2;

--- a/war/src/main/less/base-styles-v2.less
+++ b/war/src/main/less/base-styles-v2.less
@@ -4,11 +4,20 @@
   */
 
 html {
-  // Ensure that the 1rem size is 16px and scales with the browser settings
-  // This is needed because bootstrap 3 overrides the font-size when loaded
-  font-size: 100% !important;
+  // Ensure that the 1rem size is 16px and scales with the browser zoom
+  // This is needed because bootstrap 3 overrides the font-size when loaded.
+  //
+  // It's set to 16px instead of 100% because using percentages would trigger
+  // known browser bugs where elements with a font-family: monospace declaration
+  // would not respect relative font-size rules.
+  // The downside is that the page does not resize with the browser's font size,
+  // only with the zoom level.
+  font-size: 16px !important;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
+@import './base/typography.less';
 @import './base/layout-commons.less';
 @import './base/style.less';
 

--- a/war/src/main/less/base/layout-commons.less
+++ b/war/src/main/less/base/layout-commons.less
@@ -1,3 +1,5 @@
+@import '../abstracts/font.less';
+
 html {
   position: relative;
   min-height: 100%;
@@ -109,13 +111,12 @@ footer {
   bottom: 0;
   left: 0;
   clear: both;
-  font-size: 12px;
+  font-size: @font-size-xs;
   text-align: right;
 }
 
 footer span {
   margin-left: 15px;
-  line-height: 14px;
 }
 
 /* -------------------------------------- */

--- a/war/src/main/less/base/style.less
+++ b/war/src/main/less/base/style.less
@@ -22,6 +22,9 @@
  * THE SOFTWARE.
  */
 
+@import '../abstracts/font.less';
+@import '../abstracts/colors.less';
+
 /* task */
 
 #tasks {
@@ -31,7 +34,6 @@
 
 #tasks .task {
   margin-bottom: 4px;
-  font-size: 14px;
   max-width: 325px;
   overflow: hidden;
   white-space: nowrap;
@@ -44,34 +46,25 @@
   margin-bottom: 20px;
 }
 
-/* Fonts etc */
-
-body, table, form, input, td, th, p, textarea, select
-{
-  font-family: Helvetica, Arial, sans-serif;
-  font-size: 13px;
-  line-height:1.4em;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+/* Panel */
+@media (min-width: 1600px) {
+  body#jenkins.j-hide-left #main-panel {
+    max-width: 75%;
+  }
 }
-
-@media (min-width:1600px){
-  body#jenkins.j-hide-left #main-panel{max-width:75%}
-  body, table, form, input, td, th, p, textarea, select, #tasks .task
-    {font-size:14px;}
-}
-@media (min-width:2000px){
-  body#jenkins.j-hide-left #main-panel{max-width:85%}
-  body, table, form, input, td, th, p, textarea, select, #tasks .task
-    {font-size:15px;}
-}
-body, table, form, td, th, p
-{
-  color: #333;
+@media (min-width: 2000px) {
+  body#jenkins.j-hide-left #main-panel {
+    max-width: 85%;
+  }
 }
 
 form {
   margin: 0;
+}
+
+input, textarea, select {
+  color: @text-color;
+  font-family: inherit;
 }
 
 td {
@@ -299,7 +292,7 @@ pre.console {
 }
 
 .setting-description {
-  font-size: 0.8em;
+  font-size: @font-size-xs;
   margin-top: 0;
   padding-top: 0;
 }
@@ -389,7 +382,7 @@ pre.console {
   display: block;
   border-bottom: 1px #090 solid;
   font-weight: bold;
-  font-size: 12pt;
+  font-size: @font-size-xs;
 }
 
 #jenkins .task-link {
@@ -420,6 +413,10 @@ pre.console {
 
 #side-panel .pane-frame:hover, #side-panel .pane-frame.mouseover {
   border: solid 1px #cecece;
+}
+
+#side-panel .pane-content td.pane {
+  font-size: @font-size-xs;
 }
 
 .pane-header, .pane-footer {
@@ -617,7 +614,10 @@ div.behavior-loading {
     left:0; right:0;
     width:100%;
     height:100%;
-    background-color: #e4e4e4; text-align: center; font-size: 300%;
+    background-color: #e4e4e4;
+    text-align: center;
+    // TODO: use a display font, maybe 3rem
+    font-size: 300%;
     opacity: 0.5;
     -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
     filter: alpha(opacity=50);
@@ -955,14 +955,13 @@ table.parameters > tbody:hover {
     position: absolute;
     padding: 0px 4px;
     cursor: pointer;
-    top: 7px;
+    top: 4px;
     right: 6px;
     opacity: 0.5;
 }
 #buildHistoryPage .build-search-row .clear:hover {
     background-color: #d3d3d3;
     border: 1px solid #bbb;
-    top: 6px;
     padding-right: 3px;
     border-top-right-radius: 2px;
 }
@@ -1036,7 +1035,7 @@ table.parameters > tbody:hover {
 }
 
 .build-row-cell {
-  font-size: 12px;
+  font-size: @font-size-xs;
 }
 
 .build-row-cell .pane.build-name {
@@ -1184,7 +1183,7 @@ table.parameters > tbody:hover {
 
 /* ========================= directory tree ========================= */
 .parentPath {
-  font-size: 1.2em;
+  font-size: @font-size-base;
   font-weight: bold;
 }
 
@@ -1237,7 +1236,7 @@ TABLE.fileList TD.fileSize {
 }
 .test-trend-caption {
   text-align: center;
-  font-size: 1.2em;
+  font-size: @font-size-base;
   font-weight: bold;
 }
 
@@ -1263,7 +1262,7 @@ table.sortable span.sortarrow {
 }
 
 .fingerprint-summary-header {
-  font-size: 1.2em;
+  font-size: @font-size-base;
   vertical-align: middle;
 }
 
@@ -1290,10 +1289,9 @@ TABLE.fingerprint-in-build TD {
 }
 
 #plugins input.uninstall {
-  font-size: 11px;
+  font-size: @font-size-xs;
   padding: 3px 5px;
   border-radius: 1px;
-  font-family: Helvetica, Arial, sans-serif;
   font-weight: bold;
   background-color: #4b758b;
   color: #eee;
@@ -1366,7 +1364,7 @@ TABLE.fingerprint-in-build TD {
     background-color: #337ab7;
     display: inline-block;
     padding: .2em .6em .3em;
-    font-size: 75%;
+    font-size: @font-size-xs;
     font-weight: 700;
     line-height: 1;
     color: #fff;
@@ -1459,7 +1457,7 @@ DIV.yahooTree td {
 }
 
 #jenkins .yuimenuitem {
-    font-size: 12px;
+    font-size: @font-size-xs;
     padding: 3px;
 }
 
@@ -1585,7 +1583,7 @@ table.progress-bar.red td.progress-bar-done {
     position:fixed;
     text-align:center;
     left:0px;
-    font-size: 2em;
+    font-size: 1.75rem;
     z-index:1000;
     border-bottom: 1px solid black;
 }
@@ -1593,7 +1591,7 @@ table.progress-bar.red td.progress-bar-done {
 /* ========================= YUI dialog ========================= */
 
 .dialog .hd {
-    font-size: 12px !important;
+    font-size: @font-size-xs !important;
 }
 /* discovered this margin fix by a trial and error. This can very well be a totally wrong fix, or perhaps updating
  to the latest YUI will fix this? */
@@ -1635,7 +1633,7 @@ table.progress-bar.red td.progress-bar-done {
 /* ========================= logRecords.jelly ================== */
 
 .logrecord-metadata {
-    font-size: 70%;
+    font-size: @font-size-xs;
 }
 
 .logrecord-metadata-new {
@@ -1719,14 +1717,13 @@ select.select-ajax-pending {
 }
 #jenkins .yui-button .btn,
 #jenkins .yui-button button {
-  font-size: 12px;
+  font-size: @font-size-xs;
   padding: 3px 20px;
   *border: 0;
   border-radius: 1px;
 
   border: 1px solid #cccccc;
   background-color: #e0e0e0;
-  font-family: Helvetica, Arial, sans-serif;
 
   color: #505050;
   font-weight: bold;
@@ -1827,6 +1824,7 @@ select.select-ajax-pending {
 }
 
 .alert {
+    font-size: @font-size-sm;
     padding: 15px;
     margin-bottom: 20px;
     border: 1px solid transparent;
@@ -1972,15 +1970,14 @@ body.no-sticker #bottom-sticker {
 }
 
 .manage-option dl dt {
-    font-size: 16px;
-    line-height: 24px;
+    font-size: @font-size-base;
 }
 
 .manage-option dl dd {
     margin-left: 0;
     line-height: 20px;
     color: #333;
-    font-size: 14px;
+    font-size: @font-size-sm;
 }
 
 .manage-option a {

--- a/war/src/main/less/base/typography.less
+++ b/war/src/main/less/base/typography.less
@@ -1,0 +1,88 @@
+@import '../abstracts/font.less';
+@import '../abstracts/colors.less';
+
+body,
+p {
+  font-family: @font-family-sans;
+  font-size: @font-size-sm;
+  line-height: @line-height-base;
+  color: @text-color;
+}
+
+@media screen and (min-width: 1600px) {
+}
+
+@media screen and (min-width: 1600px) {
+}
+
+table,
+td,
+th,
+form,
+input,
+textarea,
+select {
+  font-size: @font-size-sm;
+}
+
+// Reset monospaced font-size, because browsers reduce it by default to ~81%
+pre,
+code,
+kbd,
+samp,
+tt {
+  font-size: @font-size-monospace;
+}
+
+/*
+ * Headings
+ */
+
+h1,
+.h1,
+h2,
+.h2,
+h3,
+.h3,
+h4,
+.h4,
+h5,
+.h5,
+h6,
+.h6 {
+  line-height: @line-height-heading;
+  font-weight: bold;
+  display: block;
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+h1,
+.h1 {
+  font-size: 2rem;
+}
+
+h2,
+.h2 {
+  font-size: 1.75rem;
+}
+
+h3,
+.h3 {
+  font-size: 1.5rem;
+}
+
+h4,
+.h4 {
+  font-size: 1.25rem;
+}
+
+h5,
+.h5 {
+  font-size: 1rem;
+}
+
+h6,
+.h6 {
+  font-size: 0.875;
+}

--- a/war/src/main/less/modules/page-header.less
+++ b/war/src/main/less/modules/page-header.less
@@ -1,3 +1,4 @@
+@import "../abstracts/font.less";
 @import "../abstracts/colors.less";
 
 .page-header {
@@ -5,11 +6,8 @@
     display: flex;
     align-items: center;
     height: 3.5rem;
-
-    font-family: Roboto, Helvetica, Arial, sans-serif;
-    font-size: 1rem;
-    line-height: 1.5;
-
+    font-size: @font-size-base;
+    line-height: @line-height-base;
     background-color: @header-bg-classic;
 }
 
@@ -108,7 +106,7 @@ a.page-header__brand-link {
 // the YUI Autocomplete module
 #searchform {
     position: relative;
-    font-family: Roboto, Helvetica, Arial, sans-serif;
+    font-family: @font-family-sans;
     display: inline-block;
     display: inline-flex;
     height: 2.5rem;
@@ -121,11 +119,10 @@ a.page-header__brand-link {
     padding: 0.25rem 2.5rem;
     margin: 0;
 
-    font-size: 1rem;
-    line-height: 1.5;
+    font-size: @font-size-base;
+    line-height: @line-height-base;
     font-weight: bold;
     color: @search-input-color;
-    font-family: Roboto, Helvetica, Arial, sans-serif;
 
     border-radius: @header-item-border-radius;
     border: 3px solid white;
@@ -206,8 +203,8 @@ a.page-header__brand-link {
 #search-box-completion LI {
     white-space: nowrap;
     padding: 0.25rem 1.25rem;
-    font-size: 1rem;
-    line-height: 1.5;
+    font-size: @font-size-base;
+    line-height: @line-height-base;
     overflow: hidden;
     text-overflow: ellipsis;
 }

--- a/war/src/main/less/pluginSetupWizard.less
+++ b/war/src/main/less/pluginSetupWizard.less
@@ -2,7 +2,8 @@
 @import (css) '../fonts/icomoon/css/icomoon.css';
 @import (css) '../fonts/google-fonts/roboto/css/roboto.css';
 
-.bootstrap-3 * {
+.bootstrap-3 *,
+.bootstrap-3 [class*='col-'] {
     // simple reset
     margin: initial;
     padding: initial;
@@ -17,13 +18,7 @@
     z-index: 1000;
     background: rgba(0,0,0,.2);
     text-align: initial;
-    font-family: sans-serif;
-
-
-    table, form, input, td, th, p, textarea, select,h1,h2,h3,h4,h5{
-      font-family:'roboto',sans-serif;
-    }
-
+    font-size: 13px;
 
     input,password { // get rid of the ms X (it doesn't fire a change event!), we provide our own
         &::-ms-clear { width : 0; height: 0; }
@@ -71,7 +66,6 @@
         position: relative;
         margin: 0 auto;
         max-width:992px;
-        font-family:'roboto',sans-serif;
     }
 
     .modal-content {
@@ -392,7 +386,7 @@
 
                     input[type=checkbox] {
                         float: left;
-                        margin: 2px -18px;
+                        margin: 3px -18px;
                         vertical-align: middle;
                     }
 
@@ -429,7 +423,7 @@
 						height: 11px;
 						content: '';
 						left: 2px;
-						top: 2px;
+						top: 3px;
 						background: @badge-color;
 						border-radius: 4px;
 					}
@@ -439,7 +433,7 @@
 						font: 15px FontAwesome;
 						text-indent: 0;
 						position: absolute;
-						top: 0;
+						top: 1px;
 						left: 1px;
 						width: 14px;
 						height: 14px;
@@ -454,6 +448,7 @@
 						width: 16px;
 						height: 16px;
 						font-size: 17px;
+                        line-height: 17px;
 						left: 0px;
 						top: -1px;
 					}
@@ -479,8 +474,8 @@
 								content: '\f0d9';
 								font: 15px FontAwesome;
 								display: inline-block;
-								width: 13px; 
-								height: 13px; 
+								width: 13px;
+								height: 13px;
 								margin: -4px -2px 0px 1px;
 								vertical-align: middle;
 							}
@@ -717,6 +712,7 @@
             &:before { // pending
                 font-family: FontAwesome;
                 font-size: 17px;
+                line-height: 17px;
                 content: '\f10c';
                 color: rgba(0,0,0,.1);
                 position: absolute;
@@ -946,4 +942,16 @@ body .plugin-setup-wizard { // need specificity, revisit the CSS inclusion order
 
 .bootstrap-3 {
     @import (less) '../../../node_modules/bootstrap/less/bootstrap.less';
+}
+
+.bootstrap-3 [class*='col-'] {
+    // simple reset
+    margin: initial;
+    padding: initial;
+}
+
+.bootstrap-3 .categories,
+.bootstrap-3 .plugins {
+    padding-left: 0;
+    padding-right: 0;
 }

--- a/war/src/main/less/ui-refresh-overrides.less
+++ b/war/src/main/less/ui-refresh-overrides.less
@@ -1,4 +1,5 @@
 @import "./abstracts/colors.less";
+@import "./abstracts/font.less";
 
 .ui-refresh {
     .page-header {
@@ -17,9 +18,8 @@
         align-items: center;
         height: 100%;
         padding: 16px 24px;
-        font-size: 16px;
+        font-size: @font-size-base;
         font-weight: bold;
-        line-height: 1.5;
         background-color: @logo-bg;
         // TODO: comment on browser support for clip-path
         clip-path: polygon(0 0, 100% 0, 95% 100%, 0 100%);


### PR DESCRIPTION
See [JENKINS-60921](https://issues.jenkins-ci.org/browse/JENKINS-60921).

This PR aims to modernize and normalize the base typographic settings of Jenkins. The main goals are:
- Move away from old and custom fonts and use the native fonts for each browser / OS combo (i.e. Segoe UI on Windows). This has the benefit of fitting  the user OS while reducing the frontend payload.
- Normalize font sizes towards a 14px font size for normal body copy. This size is the most commonly used on tools similar to Jenkins. Some UI elements may use 12px or 16px font sizes for contrast (i.e. form help messages).
- Default line height has been upped to 1.5 times the font size, in order to improve legibility.
- Update the headings hierarchy (see below). Headings have a 1.2 line height. Add CSS classes that mimic the heading styles so that they can be reused across the application.
- Stop using bootstrap 3 on Jenkins core. Wasn't removed because some plugins may depend on it.

This PR does no:
- Change font sizes for the setup wizard. The reason is that its layout is brittle and risk breaking. Small fixes to account for line height were done.
- Make font sizes responsive.
- Update form section headers.
- Rethink form sizes, using bigger forms in some UI elements.

Some of these items fall under a future iteration on [JENKINS-61367](https://issues.jenkins-ci.org/browse/JENKINS-61367).


This PR can be tested using the following docker image:
`docker run -p  8080:8080 fqueiruga/jenkins-new-ux:jenkins-60921_revisit-base-typography`

#### TODO:
- [ ] Double check that it works on IE11

#### Headings hierarchy
<details>
<summary>Click to view</summary>

- H1: 32px
- H2: 28px
- H3: 24px
- H4: 20px
- H5: 16px
- H6: 14px
</details>

### Screenshots
<details>
<summary>Click to view</summary>

Old home page
<img width="1679" alt="home_old" src="https://user-images.githubusercontent.com/5738588/76100725-725f3d00-5fcd-11ea-8ee5-3733abc113ac.png">

New home page, OSX
<img width="1680" alt="home_new_osx" src="https://user-images.githubusercontent.com/5738588/76100746-7c813b80-5fcd-11ea-9e21-c1e27c16f03d.png">

New home page, Ubuntu
![home_new_ubuntu](https://user-images.githubusercontent.com/5738588/76100773-8dca4800-5fcd-11ea-9191-8a6266c56eb0.png)

Old job page
<img width="1680" alt="job_old" src="https://user-images.githubusercontent.com/5738588/76100851-b6ead880-5fcd-11ea-96f3-a09d2f261159.png">

New job page, OSX
<img width="1680" alt="job_new_osx" src="https://user-images.githubusercontent.com/5738588/76100872-c0744080-5fcd-11ea-9a1b-19b10d0dca6d.png">

New job page, Ubuntu
![job_new_ubuntu](https://user-images.githubusercontent.com/5738588/76100877-c407c780-5fcd-11ea-8a47-9945d775e331.png)

Old job form
<img width="1680" alt="form_old" src="https://user-images.githubusercontent.com/5738588/76100918-d2ee7a00-5fcd-11ea-8628-780522609d02.png">

New job form, OSX
<img width="1680" alt="form_new_osx" src="https://user-images.githubusercontent.com/5738588/76100925-d4b83d80-5fcd-11ea-897b-0bd23ebc9810.png">

New job form, Ubuntu
![form_new_ubuntu](https://user-images.githubusercontent.com/5738588/76100937-d71a9780-5fcd-11ea-9dda-dcba71b363f2.png)

Old security config
<img width="1680" alt="form_2_old" src="https://user-images.githubusercontent.com/5738588/76100969-e6014a00-5fcd-11ea-81bc-bf66aee45f9b.png">

New security config, OSX
<img width="1680" alt="form_2_new_osx" src="https://user-images.githubusercontent.com/5738588/76100974-e7cb0d80-5fcd-11ea-8019-90434fcc37dc.png">

New security config, Ubuntu
![form_2_new_ubuntu](https://user-images.githubusercontent.com/5738588/76100979-ea2d6780-5fcd-11ea-9182-95dfcfd31311.png)

Old plugins table
<img width="1680" alt="plugins_old" src="https://user-images.githubusercontent.com/5738588/76101060-13e68e80-5fce-11ea-9348-6bfc9e08e533.png">

New plugins table, OSX
<img width="1680" alt="plugins_new_osx" src="https://user-images.githubusercontent.com/5738588/76101081-1f39ba00-5fce-11ea-8e7d-a5843df938e3.png">

New plugins table, Ubuntu
![plugins_new_ubuntu](https://user-images.githubusercontent.com/5738588/76101086-219c1400-5fce-11ea-97a5-0e823f6e6b67.png)

</details>



### Proposed changelog entries

* Jenkins now uses modern system fonts provided by the browser when possible.
* Changes in font size for body copy and headings to improve consistency and legibility.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] JIRA issue is well described
- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

